### PR TITLE
Eliminated warnings & Updated code from default edition 2015 to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "quick-xml"
 version = "0.22.0"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "High performance xml reader and writer"
+edition = "2021"
 
 documentation = "https://docs.rs/quick-xml"
 repository = "https://github.com/tafia/quick-xml"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,7 +33,7 @@ pub enum Error {
     /// Duplicate attribute
     DuplicatedAttribute(usize, usize),
     /// Escape error
-    EscapeError(::escape::EscapeError),
+    EscapeError(crate::escape::EscapeError),
 }
 
 impl From<::std::io::Error> for Error {

--- a/src/events/attributes.rs
+++ b/src/events/attributes.rs
@@ -2,9 +2,9 @@
 //!
 //! Provides an iterator over attributes key/value pairs
 
-use errors::{Error, Result};
-use escape::{do_unescape, escape};
-use reader::{is_whitespace, Reader};
+use crate::errors::{Error, Result};
+use crate::escape::{do_unescape, escape};
+use crate::reader::{is_whitespace, Reader};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::BufRead;
@@ -359,7 +359,7 @@ impl<'a> Iterator for Attributes<'a> {
                 return Some(Ok(Attribute {
                     key: &self.bytes[$key],
                     value: Cow::Borrowed(&self.bytes[$val]),
-                }));
+                }))
             };
         }
 
@@ -426,10 +426,10 @@ impl<'a> Iterator for Attributes<'a> {
                 match bytes.by_ref().find(|&(_, &b)| b == *quote) {
                     Some((j, _)) => {
                         self.position = j + 1;
-                        attr!(start_key..end_key, i + 1..j)
+                        attr!(start_key..end_key, i + 1..j);
                     }
                     None => err!(Error::UnquotedValue(i)),
-                }
+                };
             }
             Some((i, _)) if self.html => {
                 let j = bytes
@@ -441,7 +441,7 @@ impl<'a> Iterator for Attributes<'a> {
             }
             Some((i, _)) => err!(Error::UnquotedValue(i)),
             None => attr!(start_key..end_key),
-        }
+        };
     }
 }
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -11,9 +11,9 @@ use std::ops::Deref;
 use std::str::from_utf8;
 
 use self::attributes::{Attribute, Attributes};
-use errors::{Error, Result};
-use escape::{do_unescape, escape};
-use reader::Reader;
+use crate::errors::{Error, Result};
+use crate::escape::{do_unescape, escape};
+use crate::reader::Reader;
 
 use memchr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ mod errors;
 mod escapei;
 pub mod escape {
     //! Manage xml character escapes
-    pub(crate) use escapei::{do_unescape, EscapeError};
-    pub use escapei::{escape, unescape, unescape_with};
+    pub(crate) use crate::escapei::{do_unescape, EscapeError};
+    pub(crate) use crate::escapei::{escape, unescape, unescape_with};
 }
 pub mod events;
 mod reader;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -10,8 +10,8 @@ use std::str::from_utf8;
 #[cfg(feature = "encoding")]
 use encoding_rs::{Encoding, UTF_16BE, UTF_16LE};
 
-use errors::{Error, Result};
-use events::{attributes::Attribute, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+use crate::errors::{Error, Result};
+use crate::events::{attributes::Attribute, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 
 use memchr;
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,8 +2,8 @@
 
 use std::io::Write;
 
-use errors::{Error, Result};
-use events::Event;
+use crate::errors::{Error, Result};
+use crate::events::Event;
 
 /// XML writer.
 ///
@@ -210,7 +210,7 @@ impl Indentation {
 #[cfg(test)]
 mod indentation {
     use super::*;
-    use events::*;
+    use crate::events::*;
 
     #[test]
     fn self_closed() {


### PR DESCRIPTION
Eliminated most warnings that would have resulted in a hard error on future rust releases - rust issue #79813 and also updated the code from default rust edition 2015 to edition 2021, all test cases passed successfully.